### PR TITLE
rename folder name to make github actions work.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,10 @@ jobs:
 
       - name: Run migrations
         run: | 
+          cd backend
           python manage.py migrate
 
       - name: Run tests
         run: |
+          cd backend
           python manage.py test accounts


### PR DESCRIPTION
spelling error causes github actions to not run.
